### PR TITLE
feat: allow specifying number of games via arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Once installed, you should be able to run it with:
 $ python ./rps-sim.py
 ```
 
+You can specify the number of games that should be played via the `--games` argument, e.g.:
+```shell
+$ python ./rps-sim.py --games 7
+```
+Run `python ./rps-sim.py --help` for a complete list of options
+
 ## Tests
 
 Assuming you have an active `pipenv` shell: 

--- a/rps-sim.py
+++ b/rps-sim.py
@@ -1,16 +1,24 @@
+import click
 from rps.player import BotPlayer
 from rps.play import human_readable
 from rps.strategy import RandomPlayStrategy
 from rps.game import play_games
 
 
-player1 = BotPlayer(RandomPlayStrategy())
-player2 = BotPlayer(RandomPlayStrategy())
-results = play_games(player1, player2, 3)
 
-# Hard-coded, simple demonstration of a play-through
-for result in results:
-    print("Result: Player 1...", human_readable(result))
+@click.command
+@click.option("--games", default=3, type=click.IntRange(min=1, max=1000), help="Number of games to play")
+def simple_sim(games: int) -> None:
+    player1 = BotPlayer(RandomPlayStrategy())
+    player2 = BotPlayer(RandomPlayStrategy())
+    results = play_games(player1, player2, games)
+
+    for result in results:
+        # Simple message with results
+        print("Result: Player 1", human_readable(result))
+
+    print("Simulation finished.")
 
 
-print("Simulation finished.")
+if __name__ == '__main__':
+    simple_sim()


### PR DESCRIPTION
Leverage `click` (already a dependency) to accept a command line argument for specifying the number of games to play.

```shell
$ python ./rps-sim.py --games 15
Result: Player 1 draws
Result: Player 1 draws
Result: Player 1 loses
Result: Player 1 loses
Result: Player 1 wins
Result: Player 1 loses
Result: Player 1 draws
Result: Player 1 loses
Result: Player 1 draws
Result: Player 1 draws
Result: Player 1 draws
Result: Player 1 loses
Result: Player 1 loses
Result: Player 1 wins
Result: Player 1 draws
Simulation finished.

```