### PR TITLE
feat: allow specifying names of players

### DIFF
--- a/rps-sim.py
+++ b/rps-sim.py
@@ -8,14 +8,16 @@ from rps.game import play_games
 
 @click.command
 @click.option("--games", default=3, type=click.IntRange(min=1, max=1000), help="Number of games to play")
-def simple_sim(games: int) -> None:
-    player1 = BotPlayer(RandomPlayStrategy())
-    player2 = BotPlayer(RandomPlayStrategy())
+@click.option("--p1-name", default="Player 1", help="Name of first player")
+@click.option("--p2-name", default="Player 2", help="Name of second player")
+def simple_sim(games: int, p1_name: str, p2_name: str) -> None:
+    player1 = BotPlayer(RandomPlayStrategy(), p1_name)
+    player2 = BotPlayer(RandomPlayStrategy(), p2_name)
     results = play_games(player1, player2, games)
 
     for result in results:
         # Simple message with results
-        print("Result: Player 1", human_readable(result))
+        print("Result:", player1.name, human_readable(result))
 
     print("Simulation finished.")
 

--- a/rps/player.py
+++ b/rps/player.py
@@ -5,14 +5,17 @@ from .strategy import PlaySelectionStrategy
 
 
 class Player(object):
+    name: str
+
     @abc.abstractmethod
     def play(self) -> Play:
         """Required method"""
 
 
 class BotPlayer(Player):
-    def __init__(self, play_strategy: PlaySelectionStrategy):
+    def __init__(self, play_strategy: PlaySelectionStrategy, name: str = "Bot Player"):
         self.__strategy = play_strategy
+        self.name = name
 
     def play(self)  -> Play:
         return self.__strategy.play()


### PR DESCRIPTION
We allow specifying both, though for now only Player 1's name is shown.

```shell
$ python ./rps-sim.py --games 5 --p1-name "Programmer"
Result: Programmer draws
Result: Programmer wins
Result: Programmer wins
Result: Programmer loses
Result: Programmer draws
Simulation finished.

```