### PR TITLE
chore: add basic conf for pytest debug in VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# Presently ignoring, as only contains a non-portable path
-.vscode/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-python.python"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Pytest",
+            "type": "python",
+            "request": "test",
+            "console": "integratedTerminal"
+        }
+    ]
+} 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "test"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}


### PR DESCRIPTION
Adding a configuration that allowed me to debug one of the tests via MS Python extension in VS Code (extension now included among suggested).

This seemed to be needed to get around an issue where an error dialog was shown while trying to debug tests (slong the lines of "invalid message found duplicate in env path")

Note that I'm on a very recent version of VS Code (early August 2023), so this might not work on older versions.